### PR TITLE
Make vibe-core version PEP-440 compliant

### DIFF
--- a/WORKFLOW_LIST.md
+++ b/WORKFLOW_LIST.md
@@ -38,6 +38,8 @@ This includes raw data sources (e.g., Sentinel 1 and 2, LandSat, CropDataLayer) 
 
 - `sentinel1/preprocess_s1.yaml`: Downloads and preprocesses tiles of Sentinel-1 imagery that intersect with the input Sentinel-2 products in the input time range.
 
+- `sentinel1/preprocess_s1_rtc.yaml`: Downloads and preprocesses tiles of Sentinel-1 imagery that intersect with the input Sentinel-2 products in the input time range.
+
 - `sentinel2/cloud_ensemble.yaml`: Computes the cloud probability of a Sentinel-2 L2A raster using an ensemble of five cloud segmentation models.
 
 - `sentinel2/improve_cloud_mask.yaml`: Improves cloud masks by merging the product cloud mask with cloud and shadow masks computed by machine learning segmentation models.
@@ -75,6 +77,10 @@ This includes raw data sources (e.g., Sentinel 1 and 2, LandSat, CropDataLayer) 
 - `weather/download_era5.yaml`: Hourly estimated weather variables.
 
 - `weather/download_era5_monthly.yaml`: Monthly estimated weather variables.
+
+- `weather/download_gridmet.yaml`: Daily surface meteorological properties from GridMET.
+
+- `weather/download_terraclimate.yaml`: Monthly climate and hydroclimate properties from TerraClimate.
 
 - `weather/get_ambient_weather.yaml`: Downloads weather data from an Ambient Weather station.
 

--- a/cli/cr-vars.sh
+++ b/cli/cr-vars.sh
@@ -5,7 +5,7 @@
 export CONTAINER_REGISTRY_BASE="${CONTAINER_REGISTRY_BASE:-"mcr.microsoft.com/farmai/terravibes"}"
 export IMAGES="api-orchestrator worker cache"
 export IMAGES_PREFIX="${FARMVIBES_AI_IMAGE_PREFIX:-""}"
-export FARMVIBES_AI_IMAGE_TAG=${FARMVIBES_AI_IMAGE_TAG:-"2023-02-16"}
+export FARMVIBES_AI_IMAGE_TAG=${FARMVIBES_AI_IMAGE_TAG:-"2023.02.24"}
 export readonly FARMVIBES_AI_DEPLOYMENTS=(
   'terravibes-rest-api|rest-api.yaml'
   'terravibes-orchestrator|orchestrator.yaml'

--- a/src/vibe_core/setup.py
+++ b/src/vibe_core/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="vibe-core",
-    version="2023-02-16",
+    version="2023.02.24",
     author="Microsoft",
     author_email="eywa-devs@microsoft.com",
     description="FarmVibes.AI Geospatial Platform Package - vibe core package.",

--- a/src/vibe_core/vibe_core/data/__init__.py
+++ b/src/vibe_core/vibe_core/data/__init__.py
@@ -20,6 +20,7 @@ from .core_types import (
 )
 from .products import (
     ChirpsProduct,
+    ClimatologyLabProduct,
     DemProduct,
     Era5Product,
     GEDIProduct,

--- a/src/vibe_core/vibe_core/data/products.py
+++ b/src/vibe_core/vibe_core/data/products.py
@@ -87,3 +87,9 @@ class GEDIProduct(DataVibe):
 @dataclass
 class GNATSGOProduct(DataVibe):
     pass
+
+
+@dataclass
+class ClimatologyLabProduct(DataVibe):
+    url: str
+    variable: str


### PR DESCRIPTION
Use dates as versions as mentioned in [PEP-440](https://peps.python.org/pep-0440).

Merging this will fix #48.

Co-authored-by: Rafael Padilha <rpadilha@microsoft.com>