### PR TITLE
Make github pipeline ignore low disk space

### DIFF
--- a/.github/workflows/cluster-build.yml
+++ b/.github/workflows/cluster-build.yml
@@ -1,6 +1,8 @@
 name: Build FarmVibes.AI cluster
 run-name: Cluster build and helloworld test
 on: [push, pull_request, workflow_dispatch]
+env:
+  FARMVIBES_AI_SKIP_DOCKER_FREE_SPACE_CHECK: yes
 jobs: 
   build:
     name: Build and test


### PR DESCRIPTION
The farmvibes-ai.sh script will start including a disk space checker that will confirm with users whether they want to continue when on low disk space.

This PR adds an env var to skip that check in our pipelines, since those VMs have low disk space already, but that lack of disk space does not affect our tests.