### PR TITLE
Ensure `docs` dir exists when building documentation

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Ensure docs directory exists
+        run: mkdir docs || echo
+
       ### Build docs with sphinx
       - name: Build documentation pages
         uses: ammaraskar/sphinx-action@master


### PR DESCRIPTION
The current build process of the documentation fails because we don't have the `docs` directory in the repo anymore.

This PR fixes that by ensuring the `docs` directory exists before starting the docs build process.