### PR TITLE
Updating GH workflows permissions and issues to labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,6 +13,7 @@ body:
       label: In which step did you encounter the bug?
       options:
         - FarmVibes.AI setup
+        - Management script
         - Workflow execution
         - Notebook execution
         - Documentation

--- a/.github/ISSUE_TEMPLATE/info.yml
+++ b/.github/ISSUE_TEMPLATE/info.yml
@@ -17,6 +17,7 @@ body:
         - Feature request
         - Documentation
         - FarmVibes.AI setup
+        - Management script
         - Notebook
         - Workflow
         - Local cluster

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -8,6 +8,8 @@ policy:
             keys: ['Documentation']
           - name: 'FarmVibes.AI setup'
             keys: ['FarmVibes.AI setup']
+          - name: 'management script'
+            keys: ['Management script']
           - name: 'notebooks'
             keys: ['Notebook execution']
           - name: 'workflows'
@@ -23,6 +25,8 @@ policy:
         label:
           - name: 'enhancement'
             keys: ['Feature request']
+          - name: 'management script'
+            keys: ['Management script']
           - name: 'documentation'
             keys: ['Documentation']
           - name: 'FarmVibes.AI setup'

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -11,6 +11,9 @@ jobs:
     if: github.event.pull_request.merged == true || contains(fromJSON('["workflow_dispatch"]'), github.event_name)
     name: Build documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds the 'write' permission to the workflow that builds our documentation (which was breaking) and adds a new label `management script` to our issue labeler workflow. 