### PR TITLE
Updating rich and docutils to fix docpage build pipeline

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-docutils==0.18.1
+docutils==0.20.1
 sphinx==7.1.2
 sphinx_rtd_theme==2.0.0
 sphinxcontrib.mermaid==0.8.1

--- a/src/vibe_core/pyproject.toml
+++ b/src/vibe_core/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "requests~=2.31.0",
     "pystac~=1.6.0",
     "hydra-zen~=0.10",
-    "rich~=13.3.5",
+    "rich~=13.7.1",
     "msal==1.22.0",
 ]
 


### PR DESCRIPTION
This PR updates rich to version 13.7.1 in `vibe_core` and docutils to 0.20.1 in the docbuild requirements, to fix the docpage build generation pipeline.