### PR TITLE
Updating url for bitnami charts repo, redis and rabbitmq image tags 

### DIFF
--- a/src/vibe_core/vibe_core/cli/constants.py
+++ b/src/vibe_core/vibe_core/cli/constants.py
@@ -14,5 +14,5 @@ AZURE_CR_DOMAIN = "azurecr.io"
 # Local constants
 ONNX_SUBDIR = "onnx_resources"
 FARMVIBES_AI_LOG_LEVEL = "DEBUG"
-REDIS_IMAGE_TAG = "7.0.4-debian-11-r11"
-RABBITMQ_IMAGE_TAG = "3.10.8-debian-11-r4"
+REDIS_IMAGE_TAG = "7.4.1-debian-12-r2"
+RABBITMQ_IMAGE_TAG = "4.0.4-debian-12-r1"

--- a/src/vibe_core/vibe_core/terraform/aks/modules/kubernetes/rabbitmq.tf
+++ b/src/vibe_core/vibe_core/terraform/aks/modules/kubernetes/rabbitmq.tf
@@ -4,7 +4,7 @@
 resource "helm_release" "rabbitmq" {
   name = "rabbitmq"
 
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
   chart      = "rabbitmq"
   namespace  = var.namespace
 

--- a/src/vibe_core/vibe_core/terraform/aks/modules/kubernetes/redis.tf
+++ b/src/vibe_core/vibe_core/terraform/aks/modules/kubernetes/redis.tf
@@ -4,7 +4,7 @@
 resource "helm_release" "redis" {
   name = "redis"
 
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
   chart      = "redis"
   namespace  = var.namespace
 

--- a/src/vibe_core/vibe_core/terraform/local/modules/kubernetes/rabbitmq.tf
+++ b/src/vibe_core/vibe_core/terraform/local/modules/kubernetes/rabbitmq.tf
@@ -4,7 +4,7 @@
 resource "helm_release" "rabbitmq" {
   name = "rabbitmq"
 
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
   chart      = "rabbitmq"
   namespace  = var.namespace
 

--- a/src/vibe_core/vibe_core/terraform/local/modules/kubernetes/redis.tf
+++ b/src/vibe_core/vibe_core/terraform/local/modules/kubernetes/redis.tf
@@ -4,7 +4,7 @@
 resource "helm_release" "redis" {
   name = "redis"
 
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
   chart      = "redis"
   namespace  = var.namespace
 


### PR DESCRIPTION
This PR fixes an issue in which cluster setup would fail with an `Error: could not download chart: invalid_reference: invalid tag` error message when installing rabbitmq. This is related to [this issue in bitnami repo](https://github.com/bitnami/charts/issues/30582), and fixes issue #203. 

This PR also updates the redis and rabbitmq image tags to the latest versions to ensure compatibility with the latest dependencies and security patches.