### PR TITLE
Restore LFS files when building images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,8 @@ jobs:
           image-name: cache
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:


### PR DESCRIPTION
The current build process fails to include model weights in worker images because we are failing to restore LFS files.

Fixes #208